### PR TITLE
Porting to IDAPython 7.x

### DIFF
--- a/Type1/Script/Deobfuscate.py
+++ b/Type1/Script/Deobfuscate.py
@@ -35,7 +35,7 @@ def Check_stack_pointer(address1, address2):
 	sp2 = get_spd(address2)
 	return sp1 == sp2
 
-def Find_Pattern_1(image, startEA, endEA, code):
+def Find_Pattern_1(image, start_ea, end_ea, code):
 
 	list_ = []
 	start_junk_code = 0
@@ -44,7 +44,7 @@ def Find_Pattern_1(image, startEA, endEA, code):
 	deep_2 = 0
 
 
-	for insn in md.disasm(code, startEA):
+	for insn in md.disasm(code, start_ea):
 		if insn.mnemonic == 'lea' and insn.operands[0].type == X86_OP_REG and insn.reg_name(insn.operands[0].reg) == 'esp' and insn.operands[1].type == X86_OP_MEM and  insn.reg_name(insn.operands[1].mem.base) == 'esp' and insn.operands[1].mem.disp == -4:
 			list_.append(insn.address)
 			deep_1 += 1
@@ -53,36 +53,36 @@ def Find_Pattern_1(image, startEA, endEA, code):
 				start_junk_code = list_.pop()
 			end_junk_code = insn.address
 			if not Check_stack_pointer(start_junk_code+4, end_junk_code):
-				write_log( "Type 1: supcilious stack pointer 0x%x"%startEA)
+				write_log( "Type 1: supcilious stack pointer 0x%x"%start_ea)
 				continue
 			else:
 				write_log("Detect push junk code: begin-end: \t\t0x%x - 0x%x"%(start_junk_code,insn.address))
 				if insn.operands[1].type == X86_OP_IMM:
 					value = insn.operands[1].imm
 					assembly = 'push 0x%08x' % value
-					if image[start_junk_code-startEA] != 0x90:
+					if image[start_junk_code-start_ea] != 0x90:
 
-						op_len = patch_code(image,start_junk_code, start_junk_code-startEA, assembly)
-						patch(image, start_junk_code -startEA+op_len,(end_junk_code+insn.size- start_junk_code-op_len)*'\x90')
+						op_len = patch_code(image,start_junk_code, start_junk_code-start_ea, assembly)
+						patch(image, start_junk_code -start_ea+op_len,(end_junk_code+insn.size- start_junk_code-op_len)*'\x90')
 				if insn.operands[1].type == X86_OP_REG:
 					
 					
 					reg_value = insn.reg_name(insn.operands[1].reg)
 					assembly = 'push %s' % reg_value
-					if image[start_junk_code-startEA] != 0x90:
-						op_len = patch_code(image,start_junk_code, start_junk_code-startEA, assembly)
-						patch(image, start_junk_code -startEA+op_len,(end_junk_code+insn.size- start_junk_code-op_len)*'\x90')
+					if image[start_junk_code-start_ea] != 0x90:
+						op_len = patch_code(image,start_junk_code, start_junk_code-start_ea, assembly)
+						patch(image, start_junk_code -start_ea+op_len,(end_junk_code+insn.size- start_junk_code-op_len)*'\x90')
 
 
-def Find_Pattern_2(image, startEA, endEA, code):
+def Find_Pattern_2(image, start_ea, end_ea, code):
 	start_junk_code = 0
 	reg_value = ''
 	pattern = "8D 64 24 04" #lea esp, [esp + 4]
-	end_junk_code = FindBinary(endEA, SEARCH_UP, pattern)
+	end_junk_code = find_binary(end_ea, SEARCH_UP, pattern)
 
-	if end_junk_code < startEA or end_junk_code == BADADDR:
+	if end_junk_code < start_ea or end_junk_code == BADADDR:
 		return
-	for insn in md.disasm(code, startEA):
+	for insn in md.disasm(code, start_ea):
 		if insn.address >= end_junk_code:
 			break
 		if insn.mnemonic == 'mov' and insn.operands[1].type == X86_OP_MEM and insn.reg_name(insn.operands[1].mem.base) == 'esp' and insn.operands[1].mem.disp == 0:
@@ -91,36 +91,36 @@ def Find_Pattern_2(image, startEA, endEA, code):
 					start_junk_code = insn.address
 					reg_value = insn.reg_name(insn.operands[0].reg)
 			if insn.operands[0].type == X86_OP_IMM:
-				write_log( "Supcilious block: \t\t0x%x"%startEA)
+				write_log( "Supcilious block: \t\t0x%x"%start_ea)
 	if start_junk_code != 0:
 		write_log("Detect pop junk code begin-end:\t\t 0x%x - 0x%x"%(start_junk_code,insn.address))
 
 		assembly = 'pop %s' % reg_value
-		if image[start_junk_code-startEA] != 0x90:
-			op_len = patch_code(image,start_junk_code, start_junk_code-startEA, assembly)
-			patch(image, start_junk_code-startEA+op_len,(end_junk_code+4- start_junk_code-op_len)*'\x90')
+		if image[start_junk_code-start_ea] != 0x90:
+			op_len = patch_code(image,start_junk_code, start_junk_code-start_ea, assembly)
+			patch(image, start_junk_code-start_ea+op_len,(end_junk_code+4- start_junk_code-op_len)*'\x90')
 
 def Check_same_jump(begin, end):
 	branch = ["JZ","JP", "JO","JS", "JG", "JB", "JA","JL","JE"]
 	branch_ = ["JNZ" , "JNP", "JNO", "JNS", "JLE", "JNB", "JBE","JGE","JNE", "JAE"]
 	pattern = "8D 64 24 ??" #lea esp, [esp +- ??]
-	binary_ea = FindBinary(end, SEARCH_UP, pattern)
+	binary_ea = find_binary(end, SEARCH_UP, pattern)
 	if binary_ea < begin: 
 		return
-	code = GetManyBytes(begin,end-begin)
+	code = get_bytes(begin,end-begin)
 	image = bytearray(code)
 	md = Cs(CS_ARCH_X86, CS_MODE_32)
 	md.detail = True
-	code = GetManyBytes(begin,32)
+	code = get_bytes(begin,32)
 	try:
 		insns = md.disasm(code, begin)
 		insn1 = insns.next()
 		insns.close()
 	except StopIteration:
 		return 0
-	code = GetManyBytes(PrevHead(end),32)
+	code = get_bytes(prev_head(end),32)
 	try:
-		insns = md.disasm(code, PrevHead(end))
+		insns = md.disasm(code, prev_head(end))
 		insn_last = insns.next()
 		insns.close()
 	except StopIteration:
@@ -135,9 +135,9 @@ def Check_same_jump(begin, end):
 		patch_IDA(begin,end-begin, image)
 
 
-def Patch_jmp_5(image,startEA,endEA):
-	end_basic_block = PrevHead(endEA)
-	code = GetManyBytes(end_basic_block,10)
+def Patch_jmp_5(image,start_ea,end_ea):
+	end_basic_block = prev_head(end_ea)
+	code = get_bytes(end_basic_block,10)
 	md = Cs(CS_ARCH_X86, CS_MODE_32)
 	md.detail = True
 	try:
@@ -147,18 +147,18 @@ def Patch_jmp_5(image,startEA,endEA):
 	except StopIteration:
 		return 0
 
-	if insn1.mnemonic == 'jmp' and insn1.operands[0].type == X86_OP_IMM and insn1.operands[0].imm == endEA and insn1.size == 5:
+	if insn1.mnemonic == 'jmp' and insn1.operands[0].type == X86_OP_IMM and insn1.operands[0].imm == end_ea and insn1.size == 5:
 		write_log( "Patch jmp $+5 address: \t\t0x%x " %(insn1.address))
 		patch(image, len(image)-5, 5*'\x90')
 
 for fva in Functions():
 	function = idaapi.get_func(fva)
 	for block in idaapi.FlowChart(function):
-		begin = block.startEA
-		end = block.endEA
+		begin = block.start_ea
+		end = block.end_ea
 
 		if end-begin != 0: 
-			code = GetManyBytes(begin,end-begin)
+			code = get_bytes(begin,end-begin)
 			image = bytearray()
 			image.extend(code)
 			md = Cs(CS_ARCH_X86, CS_MODE_32)
@@ -167,7 +167,7 @@ for fva in Functions():
 			Find_Pattern_2(image,begin,end,code)
 			Patch_jmp_5(image,begin,end)
 			patch_IDA(begin, end -begin, image)
-			if PrevHead(begin) != BADADDR:
-				Check_same_jump(PrevHead(begin),end)
+			if prev_head(begin) != BADADDR:
+				Check_same_jump(prev_head(begin),end)
 
 f.close()

--- a/Type1/Script/Deobfuscate_stage2.py
+++ b/Type1/Script/Deobfuscate_stage2.py
@@ -27,22 +27,22 @@ def  patch_IDA(address, size, data):
 		patch_byte(address+i, data[i])
 		i +=1
 
-def Find_stack_address(address, level, startEA):
+def Find_stack_address(address, level, start_ea):
 	sp = get_spd(address)
-	ea = PrevHead(address)
+	ea = prev_head(address)
 	while get_spd(ea)-4*level != sp:
-		if ea < startEA:
+		if ea < start_ea:
 			return 0
-		ea = PrevHead(ea)
+		ea = prev_head(ea)
 	return ea 
 
-def Fix_call(image,startEA, endEA):
+def Fix_call(image,start_ea, end_ea):
 	assembly = ''
 	pattern = "8D 64 24 ??" #lea esp, [esp +- ??]
-	binary_ea = FindBinary(endEA, SEARCH_UP, pattern)
-	if binary_ea < startEA:
+	binary_ea = find_binary(end_ea, SEARCH_UP, pattern)
+	if binary_ea < start_ea:
 		return
-	code = GetManyBytes(binary_ea,32)
+	code = get_bytes(binary_ea,32)
 	md = Cs(CS_ARCH_X86, CS_MODE_32)
 	md.detail = True
 	try:
@@ -54,19 +54,19 @@ def Fix_call(image,startEA, endEA):
 		return 0
 	if insn1.operands[1].type == X86_OP_MEM and  insn1.reg_name(insn1.operands[1].mem.base) == 'esp' and insn1.operands[1].mem.disp > 4:
 		if insn2.mnemonic == 'ret':
-			call_function  = Find_stack_address(insn2.address,1,startEA)
-			return_address_push  = Find_stack_address(insn2.address,2,startEA)
+			call_function  = Find_stack_address(insn2.address,1,start_ea)
+			return_address_push  = Find_stack_address(insn2.address,2,start_ea)
 			if call_function == 0 or return_address_push == 0:
-				write_log("Suspicious basic block at 0x%x"%startEA)
+				write_log("Suspicious basic block at 0x%x"%start_ea)
 				return 0
-			code = GetManyBytes(call_function,32)
+			code = get_bytes(call_function,32)
 			try:
 				insns = md.disasm(code, call_function)
 				insn_1 = insns.next()
 				insns.close()
 			except StopIteration:
 				return 0
-			code = GetManyBytes(return_address_push,32)
+			code = get_bytes(return_address_push,32)
 			try:
 				insns = md.disasm(code, call_function)
 				insn_2 = insns.next()
@@ -82,40 +82,40 @@ def Fix_call(image,startEA, endEA):
 				assembly = "call 0x%08x"%call_addr
 				write_log("Patch at 0x%08x: \t"%return_address_push + assembly )
 
-			if insn_2.operands[0].imm != endEA:
-				write_log( "Fix RET call: Suspicious return address in push/ret 0x%x"%startEA)
+			if insn_2.operands[0].imm != end_ea:
+				write_log( "Fix RET call: Suspicious return address in push/ret 0x%x"%start_ea)
 			
-			op_len = patch_code(image,return_address_push, return_address_push-startEA, assembly)
-			patch(image, return_address_push -startEA+op_len,(endEA- return_address_push-op_len)*'\x90')
+			op_len = patch_code(image,return_address_push, return_address_push-start_ea, assembly)
+			patch(image, return_address_push -start_ea+op_len,(end_ea- return_address_push-op_len)*'\x90')
 
 		if insn2.mnemonic == 'jmp':
-			ea_push1 = Find_stack_address(insn2.address,1,startEA)
-			code = GetManyBytes(ea_push1,10)
+			ea_push1 = Find_stack_address(insn2.address,1,start_ea)
+			code = get_bytes(ea_push1,10)
 			try:
 				insns = md.disasm(code, ea_push1)
 				insn_push = insns.next()
 				insns.close()
 			except StopIteration:
 				return 0
-			if insn_push.operands[0].imm != endEA:
-				write_log ("Fix JMP call: Suspicious return address in push/ret at 0x%x"%startEA)
+			if insn_push.operands[0].imm != end_ea:
+				write_log ("Fix JMP call: Suspicious return address in push/ret at 0x%x"%start_ea)
 
 			if insn2.operands[0].type == X86_OP_REG:
 				assembly = "call %s"%insn2.reg_name(insn2.operands[0].reg)
 				write_log(assembly+ " at 0x%x"%ea_push1)
 			if insn2.operands[0].type == X86_OP_IMM:
 				assembly = "call 0x%08x"%insn2.operands[0].imm
-			op_len = patch_code(image,ea_push1, ea_push1-startEA, assembly)
-			patch(image, ea_push1 -startEA+op_len,(endEA- ea_push1-op_len)*'\x90')
+			op_len = patch_code(image,ea_push1, ea_push1-start_ea, assembly)
+			patch(image, ea_push1 -start_ea+op_len,(end_ea- ea_push1-op_len)*'\x90')
 
 
 for fva in Functions():
 	function = idaapi.get_func(fva)
 	for block in idaapi.FlowChart(function):
-		begin = block.startEA
-		end = block.endEA
+		begin = block.start_ea
+		end = block.end_ea
 		if end-begin != 0:
-			code = GetManyBytes(begin,end-begin)
+			code = get_bytes(begin,end-begin)
 			image = bytearray()
 			image.extend(code)
 			Fix_call(image, begin, end)


### PR DESCRIPTION
IDA 7.4 turns off IDA 6.x API backwards-compatibility by default.
[Porting from IDAPython 6.x-7.3, to 7.4](https://www.hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide.shtml)